### PR TITLE
Fix platform in build scripts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,6 @@ terraform-provider-looker
 crash.log
 terraform.tfstate
 terraform.tfstate.backup
-bin
 terraform-provider-looker_v*
 go.sum
+build/

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,4 @@
 VERSION = $(shell cat VERSION | tr -d '\n')
-PLATFORM = $(shell uname -s | tr '[A-Z]' '[a-z]')_$(shell uname -m)
-TARGET = $${HOME}/.terraform.d/plugins/terraform.foxtel.com/foxtel/looker/$(VERSION)/$(PLATFORM)
 EXE = terraform-provider-looker_v$(VERSION)
 
 all : $(EXE)
@@ -15,13 +13,14 @@ terraform-provider-looker : main.go looker/*.go go.mod
 clean :
 	rm -f $(EXE)
 	rm -f terraform-provider-looker
+	rm -rf build
 
-install : $(EXE)
-	mkdir -pv $(TARGET)
-	cp -v $(EXE) $(TARGET)/$(EXE)
+install : $(EXE) build/TARGET
+	mkdir -pv $(shell cat build/TARGET)
+	cp -v $(EXE) $(shell cat build/TARGET)/$(EXE)
 
-uninstall :
-	rm -f $(TARGET)/$(EXE)
+uninstall : build/TARGET
+	rm -f $(shell cat build/TARGET)/$(EXE)
 
 go.mod :
 	go mod init github.com/billtrust/terraform-provider-looker
@@ -30,5 +29,14 @@ reinit-module : clean-module go.mod
 
 clean-module: clean
 	rm -f go.mod
+
+build:
+	mkdir -pv build
+
+build/PLATFORM: build bin/platform.sh
+	./bin/platform.sh > build/PLATFORM
+
+build/TARGET: build/PLATFORM VERSION
+	echo $${HOME}/.terraform.d/plugins/terraform.foxtel.com/foxtel/looker/$(VERSION)/$(shell cat build/PLATFORM) > build/TARGET
 
 .PHONY : clean clean-module install uninstall

--- a/bin/platform.sh
+++ b/bin/platform.sh
@@ -1,0 +1,26 @@
+#! /bin/sh -eu
+
+# This is needed because we need to know the platform name to know
+# where to put the plugin, and the platform names exposed by the go
+# runtime are weird and can't be replicated with `uname(1)`.
+
+WORK=$(mktemp -d)
+trap "rm -rf \"$WORK\"" EXIT
+cd $WORK
+
+cat > platform.go <<EOF
+package main
+
+import (
+	"fmt"
+	"runtime"
+)
+
+func main() {
+	fmt.Printf("%s_%s\n", runtime.GOOS, runtime.GOARCH)
+}
+EOF
+
+go build -o platform
+./platform
+


### PR DESCRIPTION
Terraform uses the platform constants exposed by the `go` runtime, which are weird (i.e., not the same as what the kernel provides on a `uname(2)` call). This means the plugin executable gets installed to the wrong path; sadness ensues.